### PR TITLE
Dedicate owned statistics contributions under CC0

### DIFF
--- a/CC0-STATS-CONTRIBUTIONS.md
+++ b/CC0-STATS-CONTRIBUTIONS.md
@@ -1,0 +1,83 @@
+# CC0 dedication for Autumn Skerritt's statistics contributions
+
+Effective 25 July 2026, Autumn Skerritt ("Affirmer") applies
+[CC0 1.0 Universal](LICENSES/CC0-1.0.txt) to every copyrightable
+statistics-related contribution in this repository for which the Affirmer owns
+the applicable Copyright and Related Rights.
+
+Those contributions remain available under the repository's existing
+GPL-3.0 terms as well. A recipient may therefore use a covered contribution
+under the existing GPL terms **or** under the CC0 waiver and public-license
+fallback.
+
+## Contributor identities
+
+The Git audit found the Affirmer's statistics work under these identities:
+
+- `Autumn (Bee) <github@skerritt.blog>`
+- `Autumn Skerritt <skerraut@amazon.com>`
+- `bee <autumn@skerritt.blog>`
+- `bee <github@skerritt.blog>`
+
+Identity metadata is evidence used to locate contributions; the dedication
+also covers a contribution the Affirmer can prove they authored and own even
+if an import, squash, or merge changed its recorded identity.
+
+## Exact scope
+
+The covered work is the Affirmer-authored portion of commits present in this
+fork's Git object graph on the effective date that implements, tests,
+documents, styles, or configures statistics, dashboards, goals, heatmaps,
+rollups, Anki statistics, reading/mining analytics, or statistics export.
+
+The principal path families are:
+
+- `GameSentenceMiner/util/**/*stat*`, including rollups and third-party stats;
+- `GameSentenceMiner/web/**/*stat*`, `**/*dashboard*`, `**/*goal*`,
+  `**/*heatmap*`, and their templates, CSS, JavaScript, and API/repository
+  support;
+- statistics-related database migrations, cron jobs, config, images, and
+  Jiten integration;
+- `scripts/benchmark_stats.py`;
+- `tests/**/*stat*`, and tests whose subject is a covered dashboard, goal,
+  heatmap, rollup, or statistics integration.
+
+This path list locates the work but does not turn an entire mixed-authorship
+file into CC0. In a covered file, the dedication reaches only the
+copyrightable lines, blocks, tests, documentation, and other expression owned
+by the Affirmer.
+
+Representative audited commits include:
+
+- `b36aedf7ebc2dbfc578621345f54363560528b57` — Add stats
+- `63838e097d722d207684251626c65b57f6c59457` — complete refactor of stats
+- `9e7834cbc5d5993c0c26dee8e46bda77e06454cf` — add better export csv
+- `b71c2868fa8b36d72722f4ac468223bc94e8450c` — stats
+- `d91dffdd8d3f582d3fea777323578a3c59bc3117` — stats rollup
+- `72e94349ba9f64c945ab718a4e805753dfb006a5` — initial goals
+- `cfbfb6e0967493d75cdfa1bd268411670ad4bfed` — Add new Anki & GSM stats page
+- `4fc9390be90c529afb149d98d43aaf1177074f65` — daily streak, mining efficiency, and character frequency charts
+- `670bb9f7f9f427aa9a0fb3490dd71c10d023fb4b` — reading activity heatmap and reading speed chart
+
+The complete set is determined from Git, not only this representative list:
+a commit is included when it is present in the fork on the effective date,
+uses one of the audited identities (or is otherwise provably owned by the
+Affirmer), and its diff satisfies the statistics-purpose and path scope above.
+
+## Exclusions and file notices
+
+This declaration does not apply to:
+
+- code, art, documentation, or data authored or owned by another person;
+- another contributor's portion of a co-authored, merged, or later-modified
+  file;
+- third-party dependencies, generated artifacts, trademarks, patent rights,
+  privacy/publicity rights, or content for which the Affirmer cannot grant
+  rights.
+
+Because the audited statistics files have mixed histories, this change adds no
+file-wide `SPDX-License-Identifier: CC0-1.0` notices. Such a notice may be added
+later only where Git and authorship review establish that the whole file is
+covered. The repository-wide GPL license continues to govern everything not
+expressly covered by this declaration or another notice.
+

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.


### PR DESCRIPTION
Adds the official CC0 1.0 legal text and a scoped, history-audited contribution manifest for Autumn Skerritt's copyrightable statistics work. Existing GPL-3.0 terms remain available; mixed-authorship and third-party work are expressly excluded, so no file-wide SPDX claims are made.

This PR targets the user fork only.